### PR TITLE
Better camera work on interesting things (and a little documentation)

### DIFF
--- a/Assets/Digital Painting/Docs.meta
+++ b/Assets/Digital Painting/Docs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fb92ffecb3b152e459e3d97588b80d2b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Digital Painting/Docs/InterestingThings.md
+++ b/Assets/Digital Painting/Docs/InterestingThings.md
@@ -1,0 +1,22 @@
+﻿# Interesting Things
+
+Interesting Things are items of interest in the scene. In a Digital Painting they may be, for example, 
+a scenic view that automated cameras go an view.
+
+## Creating an Interesting Thing
+
+Simply add the `Thing` component to any game object. The default settings for the `Thing` 
+are usually reasonable.
+
+### Viewing Camera
+
+Things will have a virtual camera attached automatically when they are created. However, 
+it will be disabled and this will have minimal impact (other than memory) on your scenes
+performance. This camera is used as a viewing camera when an agent investigates the Thing.
+
+Be aware that the automated placement of the viewing camera is not currently very 
+intelligent. It may well be obscured, if this is the case then either send us a patch to 
+improve the positioning of the camera (preferable) or add a `CinemachineVirtualCamera` 
+at an ideal position to view the object and attach this to `Viewing Camera` property of
+the `Thing` component.
+

--- a/Assets/Digital Painting/Docs/InterestingThings.md.meta
+++ b/Assets/Digital Painting/Docs/InterestingThings.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 586df6698e4b15e4b85f7649f33f7374
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Digital Painting/Scenes/Dev Scene.unity
+++ b/Assets/Digital Painting/Scenes/Dev Scene.unity
@@ -1685,8 +1685,8 @@ MonoBehaviour:
   m_WorldUpOverride: {fileID: 0}
   m_UpdateMethod: 2
   m_DefaultBlend:
-    m_Style: 1
-    m_Time: 6
+    m_Style: 2
+    m_Time: 8
     m_CustomCurve:
       serializedVersion: 2
       m_Curve: []

--- a/Assets/Digital Painting/Scripts/Agent/AIAgentController.cs
+++ b/Assets/Digital Painting/Scripts/Agent/AIAgentController.cs
@@ -119,7 +119,13 @@ namespace wizardscode.agent
                 timeLeftLookingAtObject -= Time.deltaTime;
                 if (timeLeftLookingAtObject < 0)
                 {
+                    // Remember we have been here so we don't come again
                     visitedThings.Add(thingOfInterest);
+
+                    // when we start moving again move away from the object as we are pretty close by now and might move into it
+                    targetRotation = Quaternion.LookRotation(-transform.forward, Vector3.up);
+
+                    // we no longer care about this thing so turn the camera off and don't focus on it anymore
                     thingOfInterest = null;
                     virtualCamera.enabled = false;
                 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install these packages using Window -> Package Manager in Unity.
 ## Features of the Digital Painting
 
   * Automated Drone Navigation - see `Scripts/Agent/DroneController`
-  * Mark Interesting Things in the scene to be explored by the drone - see `Scripts/Environment/Thing`
+  * [Mark Interesting Things](./Assets/Digital Painting/Docs/InterestingThings.md) in the scene to be explored by the drone
 
 ## Developing Digital Painting
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install these packages using Window -> Package Manager in Unity.
 ## Features of the Digital Painting
 
   * Automated Drone Navigation - see `Scripts/Agent/DroneController`
-  * [Mark Interesting Things](./Assets/Digital%2CPainting/Docs/InterestingThings.md) in the scene to be explored by the drone
+  * [Mark Interesting Things](./Assets/Digital+Painting/Docs/InterestingThings.md) in the scene to be explored by the drone
 
 ## Developing Digital Painting
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install these packages using Window -> Package Manager in Unity.
 ## Features of the Digital Painting
 
   * Automated Drone Navigation - see `Scripts/Agent/DroneController`
-  * [Mark Interesting Things](./Assets/Digital+Painting/Docs/InterestingThings.md) in the scene to be explored by the drone
+  * [Mark Interesting Things](./Assets/Digital%20Painting/Docs/InterestingThings.md) in the scene to be explored by the drone
 
 ## Developing Digital Painting
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install these packages using Window -> Package Manager in Unity.
 ## Features of the Digital Painting
 
   * Automated Drone Navigation - see `Scripts/Agent/DroneController`
-  * [Mark Interesting Things](./Assets/Digital Painting/Docs/InterestingThings.md) in the scene to be explored by the drone
+  * [Mark Interesting Things](./Assets/Digital%2CPainting/Docs/InterestingThings.md) in the scene to be explored by the drone
 
 ## Developing Digital Painting
 


### PR DESCRIPTION
When coming out of an Interesting Things look camera set the rotation of the drone in the opposite direction so that it is already moving away from the object when we return to the camera

Tweak the default blend to make it a little more natural on look camera blends

Document the Intersting Things 